### PR TITLE
fix: plugin priority value

### DIFF
--- a/apisix-authz.lua
+++ b/apisix-authz.lua
@@ -34,7 +34,7 @@ local schema = {
 
 local _M = {
     version = 0.1,
-    priority = 2555,
+    priority = 2560,
     type = 'auth',
     name = plugin_name,
     schema = schema


### PR DESCRIPTION
I came to know that two plugins can't have same priority values, the previous value coincided with another plugin's priority value so this is a small fix for it.